### PR TITLE
Swipe Navigation, Gradients, OpenFarm Integration, Compact Plant Card

### DIFF
--- a/src/api/openFarmMocks.ts
+++ b/src/api/openFarmMocks.ts
@@ -1,0 +1,89 @@
+// src/api/openFarmMocks.ts
+// Issue #30 — Mock-ups mirror the OpenFarm responses
+//
+// Fixture objects built from real OpenFarm API responses.
+// Shape is identical to what the live API returns so the same
+// normaliseOpenFarmCrop() function works on both.
+//
+// Active when import.meta.env.DEV === true (npm run dev).
+// Production builds use the live API automatically.
+
+import type { OpenFarmCropAttributes } from "../types/plant";
+
+export const openFarmMocks: Record<string, OpenFarmCropAttributes> = {
+  lettuce: {
+    name:                "Lettuce",
+    slug:                "lettuce",
+    binomial_name:       "Lactuca sativa",
+    description:
+      "Lettuce is a fast-growing annual that thrives in cool weather. Ideal for " +
+      "hydroponics and container growing. Harvest outer leaves continuously for a " +
+      "cut-and-come-again supply.",
+    sun_requirements:    "Partial Sun",
+    sowing_method:       "Direct Sow",
+    spread:              30,
+    row_spacing:         25,
+    height:              25,
+    tags_array:          ["salad", "fast-growing", "cool-season", "hydroponic"],
+    growing_degree_days: 750,
+    main_image_path:
+      "https://openfarm.cc/assets/missing_image.png",
+  },
+
+  basil: {
+    name:                "Sweet Basil",
+    slug:                "basil",
+    binomial_name:       "Ocimum basilicum",
+    description:
+      "Sweet basil is a warm-season annual herb prized for its aromatic leaves. " +
+      "Pinch growing tips regularly to prevent bolting and encourage a bushy form. " +
+      "Grows well hydroponically with slightly higher EC than leafy greens.",
+    sun_requirements:    "Full Sun",
+    sowing_method:       "Transplant",
+    spread:              35,
+    row_spacing:         30,
+    height:              45,
+    tags_array:          ["herb", "aromatic", "warm-season", "hydroponic"],
+    growing_degree_days: 1200,
+    main_image_path:
+      "https://openfarm.cc/assets/missing_image.png",
+  },
+
+  arugula: {
+    name:                "Arugula",
+    slug:                "arugula",
+    binomial_name:       "Eruca vesicaria",
+    description:
+      "Arugula is a fast-growing cool-season green with a distinctive peppery flavour. " +
+      "One of the quickest crops from seed to harvest — typically 21–40 days. " +
+      "Bolts in heat; best grown in spring or autumn.",
+    sun_requirements:    "Partial Sun",
+    sowing_method:       "Direct Sow",
+    spread:              20,
+    row_spacing:         15,
+    height:              20,
+    tags_array:          ["salad", "peppery", "cool-season", "fast-growing"],
+    growing_degree_days: 500,
+    main_image_path:
+      "https://openfarm.cc/assets/missing_image.png",
+  },
+
+  kale: {
+    name:                "Kale",
+    slug:                "kale",
+    binomial_name:       "Brassica oleracea var. sabellica",
+    description:
+      "Kale is a cold-hardy brassica that improves in flavour after a frost. " +
+      "Harvest outer leaves to keep the plant producing. One of the most nutrient-dense " +
+      "crops per square foot and highly tolerant of Pacific Northwest winters.",
+    sun_requirements:    "Full Sun",
+    sowing_method:       "Direct Sow",
+    spread:              45,
+    row_spacing:         45,
+    height:              60,
+    tags_array:          ["brassica", "cold-hardy", "superfood", "overwintering"],
+    growing_degree_days: 1000,
+    main_image_path:
+      "https://openfarm.cc/assets/missing_image.png",
+  },
+};

--- a/src/api/useOpenFarmCrop.ts
+++ b/src/api/useOpenFarmCrop.ts
@@ -1,0 +1,94 @@
+// src/api/useOpenFarmCrop.ts
+// Issue #29 — Implement OpenFarm, update plant.ts
+//
+// Hook that accepts a crop slug and returns normalised crop data.
+// In-memory cache prevents re-fetching the same slug in a session.
+// Falls back to openFarmMocks in development (import.meta.env.DEV).
+
+import { useState, useEffect } from "react";
+import { openFarmMocks }       from "./openFarmMocks";
+import {
+  normaliseOpenFarmCrop,
+  type NormalisedCrop,
+  type OpenFarmSingleResponse,
+} from "../types/plant";
+
+// ─── In-memory cache ──────────────────────────────────────────────────────────
+// Keyed by slug. Populated on first fetch; reused for subsequent calls.
+const cropCache = new Map<string, NormalisedCrop>();
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+interface UseOpenFarmCropResult {
+  crop:    NormalisedCrop | null;
+  loading: boolean;
+  error:   string | null;
+}
+
+export function useOpenFarmCrop(slug: string | undefined): UseOpenFarmCropResult {
+  const [state, setState] = useState<UseOpenFarmCropResult>({
+    crop:    null,
+    loading: !!slug,
+    error:   null,
+  });
+
+  useEffect(() => {
+    if (!slug) {
+      setState({ crop: null, loading: false, error: null });
+      return;
+    }
+
+    // Return cached result immediately if available
+    const cached = cropCache.get(slug);
+    if (cached) {
+      setState({ crop: cached, loading: false, error: null });
+      return;
+    }
+
+    let cancelled = false;
+    setState({ crop: null, loading: true, error: null });
+
+    async function load() {
+      try {
+        let normalised: NormalisedCrop;
+
+        // ── Development: use mock fixtures ────────────────────────────────────
+        if (import.meta.env.DEV && openFarmMocks[slug!]) {
+          // Simulate a short network delay so loading states are visible in dev
+          await new Promise((r) => setTimeout(r, 300));
+          normalised = normaliseOpenFarmCrop(openFarmMocks[slug!]);
+        } else {
+          // ── Production: hit the real OpenFarm API ─────────────────────────
+          const url = `https://openfarm.cc/api/v1/crops/${encodeURIComponent(slug!)}`;
+          const res = await fetch(url);
+
+          if (res.status === 404) {
+            if (!cancelled) setState({ crop: null, loading: false, error: null });
+            return;
+          }
+
+          if (!res.ok) {
+            throw new Error(`OpenFarm ${res.status}: ${res.statusText}`);
+          }
+
+          const json: OpenFarmSingleResponse = await res.json();
+          normalised = normaliseOpenFarmCrop(json.data.attributes);
+        }
+
+        cropCache.set(slug!, normalised);
+        if (!cancelled) setState({ crop: normalised, loading: false, error: null });
+
+      } catch (err) {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : "Failed to load crop data";
+          setState({ crop: null, loading: false, error: message });
+        }
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [slug]);
+
+  return state;
+}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,0 +1,117 @@
+// src/components/AppShell.tsx
+// Issues #27 & #28 — Swiping Navigation + Background Gradient on Swipe
+//
+// Top-level container that:
+//   1. Holds the active view index (0 = outdoor, 1 = indoor)
+//   2. Listens for swipe gestures via useSwipe and updates the active view
+//   3. Slides views with CSS transform: translateX (smooth, no router needed)
+//   4. Transitions a full-screen background gradient between outdoor/indoor palettes
+//
+// Gradient transition rules:
+//   - Both gradients use linear-gradient with the same stop count
+//     so CSS can interpolate between them smoothly.
+//   - The gradient lives behind the view content (z-index: 0).
+//   - Views sit on top with a transparent background.
+
+import { useState }     from "react";
+import { useSwipe }     from "../hooks/useSwipe";
+import OutdoorView      from "../outdoor/outdoor-view";
+import IndoorView       from "../indoor/indoor-view";
+
+// ─── Gradient definitions ─────────────────────────────────────────────────────
+// Must have the same structure for CSS transition to work between them.
+
+const GRADIENTS = {
+  outdoor:
+    "linear-gradient(160deg, #eef6fb 0%, #d4eaf6 40%, #e8f5e9 100%)",
+  indoor:
+    "linear-gradient(160deg, #1a2a1a 0%, #0d1f0d 40%, #1b2838 100%)",
+} as const;
+
+// ─── View tab indicator ───────────────────────────────────────────────────────
+
+function ViewIndicator({ activeIndex }: { activeIndex: number }) {
+  return (
+    <div
+      className="fixed bottom-5 left-1/2 -translate-x-1/2 flex gap-2 z-50"
+      role="tablist"
+      aria-label="Views"
+    >
+      {["Outdoor", "Indoor"].map((label, i) => (
+        <div
+          key={label}
+          role="tab"
+          aria-selected={i === activeIndex}
+          aria-label={label}
+          className="transition-all duration-300 rounded-full"
+          style={{
+            width:           i === activeIndex ? "20px" : "8px",
+            height:          "8px",
+            backgroundColor: i === activeIndex
+              ? "var(--frost-500)"
+              : "var(--color-border-strong)",
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ─── AppShell ─────────────────────────────────────────────────────────────────
+
+export default function AppShell() {
+  const [activeIndex, setActiveIndex] = useState(0); // 0 = outdoor, 1 = indoor
+
+  const swipeRef = useSwipe<HTMLDivElement>({
+    onSwipeLeft:  () => setActiveIndex(1),
+    onSwipeRight: () => setActiveIndex(0),
+  });
+
+  const gradient = activeIndex === 0 ? GRADIENTS.outdoor : GRADIENTS.indoor;
+
+  return (
+    // Full-screen container — gradient transitions on view change
+    <div
+      ref={swipeRef}
+      className="relative w-full min-h-screen overflow-hidden"
+      style={{
+        background:  gradient,
+        transition:  "background 600ms ease",
+      }}
+    >
+      {/*
+        Sliding view track:
+        Two views sit side by side (200% wide total).
+        translateX shifts by -100% to show the indoor view.
+      */}
+      <div
+        className="flex w-[200%] min-h-screen transition-transform duration-400 ease-in-out"
+        style={{
+          transform: activeIndex === 0 ? "translateX(0)" : "translateX(-50%)",
+        }}
+        aria-live="polite"
+      >
+        {/* Outdoor view — left panel */}
+        <div
+          className="w-1/2 min-h-screen"
+          aria-hidden={activeIndex !== 0}
+          inert={activeIndex !== 0 ? ("" as unknown as boolean) : undefined}
+        >
+          <OutdoorView />
+        </div>
+
+        {/* Indoor view — right panel */}
+        <div
+          className="w-1/2 min-h-screen"
+          aria-hidden={activeIndex !== 1}
+          inert={activeIndex !== 1 ? ("" as unknown as boolean) : undefined}
+        >
+          <IndoorView />
+        </div>
+      </div>
+
+      {/* Dot indicator */}
+      <ViewIndicator activeIndex={activeIndex} />
+    </div>
+  );
+}

--- a/src/components/CompactPlantCard.tsx
+++ b/src/components/CompactPlantCard.tsx
@@ -1,0 +1,221 @@
+// src/components/CompactPlantCard.tsx
+// Issue #31 — Compact Plant Card
+//
+// The primary outdoor garden card. Compact footprint so 4 cards fit
+// on a single screen without scrolling. Tapping expands an inline
+// detail strip with OpenFarm crop data (description, sun, sowing method).
+// Loading skeleton prevents layout shift while the API call resolves.
+
+import { useState }         from "react";
+import { ChevronDown, ChevronUp, Droplets, Sun, Sprout, AlertCircle,
+         CheckCircle2, Moon } from "lucide-react";
+import { useOpenFarmCrop }   from "../api/useOpenFarmCrop";
+import { cn }                from "../utils/cn";
+import type { OutdoorPlot, PlotStatus } from "../types/plant";
+
+// ─── Status config ────────────────────────────────────────────────────────────
+
+const statusConfig: Record<
+  PlotStatus,
+  { icon: React.ElementType; color: string; label: string }
+> = {
+  healthy:           { icon: CheckCircle2, color: "#16a34a", label: "Healthy" },
+  "needs-water":     { icon: Droplets,     color: "#2563eb", label: "Needs Water" },
+  "needs-attention": { icon: AlertCircle,  color: "#d97706", label: "Attention" },
+  dormant:           { icon: Moon,         color: "#94a3b8", label: "Dormant" },
+  harvested:         { icon: Sprout,       color: "#7c3aed", label: "Harvested" },
+};
+
+// ─── Detail strip skeleton ────────────────────────────────────────────────────
+
+function DetailSkeleton() {
+  return (
+    <div className="mt-3 space-y-2 animate-pulse" aria-label="Loading crop details">
+      <div className="h-3 rounded bg-[var(--color-border)] w-full" />
+      <div className="h-3 rounded bg-[var(--color-border)] w-4/5" />
+      <div className="h-3 rounded bg-[var(--color-border)] w-3/5" />
+    </div>
+  );
+}
+
+// ─── Detail strip ─────────────────────────────────────────────────────────────
+
+interface DetailStripProps {
+  slug: string | undefined;
+}
+
+function DetailStrip({ slug }: DetailStripProps) {
+  const { crop, loading, error } = useOpenFarmCrop(slug);
+
+  if (!slug) {
+    return (
+      <p className="mt-3 text-xs" style={{ color: "var(--color-text-muted)" }}>
+        No crop data linked. Add an OpenFarm slug to see growing info.
+      </p>
+    );
+  }
+
+  if (loading) return <DetailSkeleton />;
+
+  if (error || !crop) {
+    return (
+      <p className="mt-3 text-xs" style={{ color: "var(--color-text-muted)" }}>
+        Crop info unavailable right now.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-3 space-y-2">
+      {crop.description && (
+        <p
+          className="text-xs leading-relaxed line-clamp-3"
+          style={{ color: "var(--color-text-secondary)" }}
+        >
+          {crop.description}
+        </p>
+      )}
+
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        {crop.sunRequirements && (
+          <span
+            className="flex items-center gap-1 text-xs"
+            style={{ color: "var(--color-text-secondary)" }}
+          >
+            <Sun className="w-3 h-3" aria-hidden="true" />
+            {crop.sunRequirements}
+          </span>
+        )}
+        {crop.sowingMethod && (
+          <span
+            className="flex items-center gap-1 text-xs"
+            style={{ color: "var(--color-text-secondary)" }}
+          >
+            <Sprout className="w-3 h-3" aria-hidden="true" />
+            {crop.sowingMethod}
+          </span>
+        )}
+        {crop.heightCm && (
+          <span
+            className="text-xs"
+            style={{ color: "var(--color-text-secondary)" }}
+          >
+            Height: {crop.heightCm}cm
+          </span>
+        )}
+      </div>
+
+      {crop.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {crop.tags.slice(0, 4).map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full px-2 py-0.5 text-[10px] font-medium"
+              style={{
+                backgroundColor: "var(--frost-100)",
+                color:           "var(--frost-700)",
+              }}
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── CompactPlantCard ─────────────────────────────────────────────────────────
+
+interface CompactPlantCardProps {
+  plot: OutdoorPlot;
+}
+
+export function CompactPlantCard({ plot }: CompactPlantCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const { icon: Icon, color, label } = statusConfig[plot.status];
+  const Chevron = expanded ? ChevronUp : ChevronDown;
+
+  return (
+    <div
+      className="rounded-xl border bg-[var(--color-surface)] shadow-[var(--shadow-sm)]
+                 transition-shadow hover:shadow-[var(--shadow-md)]"
+      style={{ borderColor: "var(--color-border)" }}
+    >
+      {/* ── Main row — always visible ── */}
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className="w-full text-left px-4 py-3 flex items-center gap-3
+                   min-h-[var(--touch-target-min)]
+                   focus-visible:outline-none focus-visible:ring-2
+                   focus-visible:ring-[var(--frost-500)] rounded-xl"
+        aria-expanded={expanded}
+        aria-label={`${plot.crop} in ${plot.name} — ${label}. ${expanded ? "Collapse" : "Expand"} details.`}
+      >
+        {/* Status icon */}
+        <Icon
+          className="w-4 h-4 shrink-0"
+          style={{ color }}
+          aria-hidden="true"
+        />
+
+        {/* Crop + plot name */}
+        <div className="flex-1 min-w-0">
+          <p
+            className="text-sm font-semibold truncate"
+            style={{
+              color:      "var(--color-text-primary)",
+              fontFamily: "var(--font-heading)",
+            }}
+          >
+            {plot.crop}
+          </p>
+          <p
+            className="text-xs truncate"
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            {plot.name}
+          </p>
+        </div>
+
+        {/* Last watered */}
+        {plot.lastWatered && (
+          <span
+            className="flex items-center gap-1 text-xs shrink-0 mr-1"
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            <Droplets className="w-3 h-3" aria-hidden="true" />
+            {new Date(plot.lastWatered).toLocaleDateString("en-US", {
+              month: "short",
+              day:   "numeric",
+            })}
+          </span>
+        )}
+
+        {/* Expand chevron */}
+        <Chevron
+          className="w-4 h-4 shrink-0"
+          style={{ color: "var(--color-text-muted)" }}
+          aria-hidden="true"
+        />
+      </button>
+
+      {/* ── Expandable detail strip ── */}
+      <div
+        className={cn(
+          "overflow-hidden transition-all duration-300 ease-in-out",
+          expanded ? "max-h-[300px] opacity-100" : "max-h-0 opacity-0"
+        )}
+        aria-hidden={!expanded}
+      >
+        <div
+          className="px-4 pb-4 border-t"
+          style={{ borderColor: "var(--color-border)" }}
+        >
+          <DetailStrip slug={plot.openFarmSlug} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useSwipe.ts
+++ b/src/hooks/useSwipe.ts
@@ -1,0 +1,73 @@
+// src/hooks/useSwipe.ts
+// Issue #27 — Swiping Navigation with Gesture Threshold
+//
+// Custom hook that attaches touch event listeners to a ref element
+// and fires callbacks when the horizontal gesture exceeds SWIPE_THRESHOLD_PX.
+//
+// Threshold tuning:
+//   Too low  → accidental swipes from taps / vertical scrolls
+//   Too high → gesture feels unresponsive
+//   60px landed well across phone and trackpad testing.
+
+import { useEffect, useRef, useCallback } from "react";
+
+export const SWIPE_THRESHOLD_PX = 60;
+
+interface UseSwipeOptions {
+  onSwipeLeft?:  () => void;
+  onSwipeRight?: () => void;
+  /** Override the default 60px threshold */
+  threshold?:    number;
+  /** Disable the hook without removing the ref */
+  disabled?:     boolean;
+}
+
+export function useSwipe<T extends HTMLElement = HTMLDivElement>(
+  options: UseSwipeOptions
+) {
+  const { onSwipeLeft, onSwipeRight, threshold = SWIPE_THRESHOLD_PX, disabled } = options;
+  const ref        = useRef<T>(null);
+  const startX     = useRef<number | null>(null);
+  const startY     = useRef<number | null>(null);
+
+  const handleTouchStart = useCallback((e: TouchEvent) => {
+    startX.current = e.touches[0].clientX;
+    startY.current = e.touches[0].clientY;
+  }, []);
+
+  const handleTouchEnd = useCallback((e: TouchEvent) => {
+    if (startX.current === null || startY.current === null) return;
+
+    const deltaX = e.changedTouches[0].clientX - startX.current;
+    const deltaY = e.changedTouches[0].clientY - startY.current;
+
+    // Ignore if vertical movement dominates — user is likely scrolling
+    if (Math.abs(deltaY) > Math.abs(deltaX)) {
+      startX.current = null;
+      startY.current = null;
+      return;
+    }
+
+    if (deltaX < -threshold && onSwipeLeft)  onSwipeLeft();
+    if (deltaX >  threshold && onSwipeRight) onSwipeRight();
+
+    startX.current = null;
+    startY.current = null;
+  }, [threshold, onSwipeLeft, onSwipeRight]);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || disabled) return;
+
+    // passive: true — lets browser start scrolling without waiting for JS
+    el.addEventListener("touchstart", handleTouchStart, { passive: true });
+    el.addEventListener("touchend",   handleTouchEnd,   { passive: true });
+
+    return () => {
+      el.removeEventListener("touchstart", handleTouchStart);
+      el.removeEventListener("touchend",   handleTouchEnd);
+    };
+  }, [handleTouchStart, handleTouchEnd, disabled]);
+
+  return ref;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,17 @@
+// src/main.tsx
+// Updated Week 7 — renders AppShell instead of a single view.
+// AppShell manages swipe navigation between outdoor and indoor views.
 
-  import { createRoot } from "react-dom/client";
-  import App from "./app/App.tsx";
-  import "./styles/index.css";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import AppShell       from "./components/AppShell";
+import "./index.css";
 
-  createRoot(document.getElementById("root")!).render(<App />);
-  
+const root = document.getElementById("root");
+if (!root) throw new Error("#root element not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <AppShell />
+  </StrictMode>
+);

--- a/src/outdoor/outdoor-view.tsx
+++ b/src/outdoor/outdoor-view.tsx
@@ -1,86 +1,130 @@
 // src/outdoor/outdoor-view.tsx
-// Updated Week 5 — wired up FrostCountdown, ClimateCarousel, FirstFrostHeader,
-// and the useWeather hook replacing the Week 3 placeholder shell.
+// Updated Week 7 — replaced placeholder skeleton with CompactPlantCard grid.
+// Mock outdoor plot data lives here for now (future: shared data layer).
 
-import { useWeather }          from "../api/useWeather";
-import { FirstFrostHeader }    from "../components/FirstFrostHeader";
-import { FrostCountdown }      from "../components/FrostCountdown";
-import { ClimateCarousel }     from "../components/ClimateCarousel";
+import { useWeather }           from "../api/useWeather";
+import { FirstFrostHeader }     from "../components/FirstFrostHeader";
+import { FrostCountdown }       from "../components/FrostCountdown";
+import { ClimateCarousel }      from "../components/ClimateCarousel";
+import { CompactPlantCard }     from "../components/CompactPlantCard";
+import type { OutdoorPlot }     from "../types/plant";
 
-// Week 3 placeholder stub — will be replaced with real PlantCard grid in Week 6
-function PlantCardGrid() {
-  return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-      {[1, 2, 3, 4].map((n) => (
-        <div
-          key={n}
-          className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4 h-24 animate-pulse"
-          aria-hidden="true"
-        />
-      ))}
-    </div>
-  );
-}
+// ─── Mock outdoor plot data ───────────────────────────────────────────────────
+// Moved here from the Week 5 placeholder. Will migrate to a shared
+// data layer once persistence is added.
+
+const mockPlots: OutdoorPlot[] = [
+  {
+    id:            "plot-1",
+    name:          "Raised Bed A",
+    crop:          "Kale",
+    status:        "healthy",
+    plantedDate:   "2026-02-15",
+    lastWatered:   "2026-03-17",
+    openFarmSlug:  "kale",
+    notes:         "Curly kale. Growing well despite recent cold snap.",
+  },
+  {
+    id:            "plot-2",
+    name:          "Raised Bed B",
+    crop:          "Spinach",
+    status:        "healthy",
+    plantedDate:   "2026-02-20",
+    lastWatered:   "2026-03-18",
+    openFarmSlug:  "spinach",
+  },
+  {
+    id:            "plot-3",
+    name:          "Container Row",
+    crop:          "Swiss Chard",
+    status:        "needs-water",
+    plantedDate:   "2026-03-01",
+    lastWatered:   "2026-03-16",
+    openFarmSlug:  "swiss-chard",
+  },
+  {
+    id:            "plot-4",
+    name:          "Border Bed",
+    crop:          "Garlic",
+    status:        "dormant",
+    plantedDate:   "2025-10-10",
+    lastWatered:   "2026-03-10",
+    openFarmSlug:  "garlic",
+    notes:         "Overwintered. Scapes forming.",
+  },
+];
+
+// ─── View ─────────────────────────────────────────────────────────────────────
 
 export default function OutdoorView() {
   const { data, loading, error } = useWeather();
-
-  // Fallback temperature while loading — mid-watch state for PNW prototype
   const tempF = data?.current.tempF ?? 34;
 
   return (
     <>
-      {/* Skip link — keyboard accessibility */}
       <a
         href="#outdoor-main"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50
-                   focus:bg-white focus:px-4 focus:py-2 focus:rounded focus:shadow-lg
-                   focus:text-[var(--frost-900)] focus:font-medium"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2
+                   focus:z-50 focus:bg-white focus:px-4 focus:py-2 focus:rounded
+                   focus:shadow-lg focus:text-[var(--frost-900)] focus:font-medium"
       >
         Skip to main content
       </a>
 
-      <div className="flex flex-col min-h-screen bg-[var(--color-background)]">
-
-        {/* Sticky header — Issue #21 */}
+      <div className="flex flex-col min-h-screen bg-transparent">
         <FirstFrostHeader tempF={tempF} />
 
-        <main id="outdoor-main" className="flex-1 flex flex-col gap-5 pb-8">
+        <main id="outdoor-main" className="flex-1 flex flex-col gap-5 pb-12">
 
-          {/* Loading / error states */}
+          {/* Loading skeleton */}
           {loading && (
             <div className="px-4 pt-4">
-              <div className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] h-36 animate-pulse" />
+              <div
+                className="rounded-2xl border h-36 animate-pulse"
+                style={{
+                  borderColor:     "var(--color-border)",
+                  backgroundColor: "var(--color-surface)",
+                }}
+              />
             </div>
           )}
 
+          {/* API error */}
           {error && (
             <div
-              className="mx-4 mt-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+              className="mx-4 mt-4 rounded-xl border border-red-200 bg-red-50
+                         px-4 py-3 text-sm text-red-700"
               role="alert"
             >
               Could not load weather data. Showing last known conditions.
             </div>
           )}
 
-          {/* Frost countdown — Issue #18 */}
+          {/* Frost countdown */}
           {!loading && (
             <div className="px-4 pt-4">
               <FrostCountdown tempF={tempF} />
             </div>
           )}
 
-          {/* Climate carousel — Issue #20 */}
+          {/* Climate carousel */}
           {data && data.hourly.length > 0 && (
             <ClimateCarousel hours={data.hourly} />
           )}
 
-          {/* Plant card grid — placeholder until Week 6 */}
+          {/* Plant card grid — now real CompactPlantCards */}
           <section aria-label="Garden plots" className="px-4">
-            <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-[var(--color-text-muted)]">
+            <p
+              className="mb-3 text-xs font-semibold uppercase tracking-widest"
+              style={{ color: "var(--color-text-muted)" }}
+            >
               Your Garden
             </p>
-            <PlantCardGrid />
+            <div className="flex flex-col gap-2">
+              {mockPlots.map((plot) => (
+                <CompactPlantCard key={plot.id} plot={plot} />
+              ))}
+            </div>
           </section>
 
         </main>

--- a/src/types/plant.ts
+++ b/src/types/plant.ts
@@ -1,0 +1,96 @@
+// src/types/plant.ts
+// Issue #29 — Implement OpenFarm, update plant.ts
+//
+// Updated to accurately model the OpenFarm API response shape.
+// Previous version had placeholder fields — this maps the real
+// data.attributes object returned by the API.
+// https://openfarm.cc/api/v1/crops?filter=<slug>
+
+// ─── OpenFarm API types ───────────────────────────────────────────────────────
+
+export interface OpenFarmCropAttributes {
+  name:                 string;
+  slug:                 string;
+  binomial_name?:       string;
+  description:          string;
+  sun_requirements?:    string;   // e.g. "Full Sun", "Partial Sun"
+  sowing_method?:       string;   // e.g. "Direct Sow", "Transplant"
+  spread?:              number;   // cm
+  row_spacing?:         number;   // cm
+  height?:              number;   // cm
+  processing_pictures?: number;
+  tags_array:           string[];
+  growing_degree_days?: number;
+  main_image_path?:     string;
+}
+
+export interface OpenFarmCropData {
+  id:         string;
+  type:       "crops";
+  attributes: OpenFarmCropAttributes;
+}
+
+export interface OpenFarmSearchResponse {
+  data: OpenFarmCropData[];
+  meta: { total: number };
+}
+
+export interface OpenFarmSingleResponse {
+  data: OpenFarmCropData;
+}
+
+// ─── Internal plant types ─────────────────────────────────────────────────────
+// These are the shapes used inside the app after normalising from the API.
+
+export type PlotStatus =
+  | "healthy"
+  | "needs-water"
+  | "needs-attention"
+  | "dormant"
+  | "harvested";
+
+export interface OutdoorPlot {
+  id:             string;
+  name:           string;
+  crop:           string;
+  status:         PlotStatus;
+  /** ISO date string */
+  plantedDate?:   string;
+  /** ISO date string */
+  lastWatered?:   string;
+  notes?:         string;
+  /** OpenFarm slug — used by useOpenFarmCrop to fetch crop details */
+  openFarmSlug?:  string;
+}
+
+/**
+ * Normalised OpenFarm crop — the subset we actually render.
+ * Safe to call with a partial API response; missing fields become undefined.
+ */
+export interface NormalisedCrop {
+  name:             string;
+  slug:             string;
+  description:      string;
+  sunRequirements?: string;
+  sowingMethod?:    string;
+  heightCm?:        number;
+  spreadCm?:        number;
+  rowSpacingCm?:    number;
+  tags:             string[];
+  imageUrl?:        string;
+}
+
+export function normaliseOpenFarmCrop(raw: OpenFarmCropAttributes): NormalisedCrop {
+  return {
+    name:             raw.name             ?? "",
+    slug:             raw.slug             ?? "",
+    description:      raw.description      ?? "",
+    sunRequirements:  raw.sun_requirements,
+    sowingMethod:     raw.sowing_method,
+    heightCm:         raw.height,
+    spreadCm:         raw.spread,
+    rowSpacingCm:     raw.row_spacing,
+    tags:             Array.isArray(raw.tags_array) ? raw.tags_array : [],
+    imageUrl:         raw.main_image_path,
+  };
+}


### PR DESCRIPTION

feat: useSwipe hook with configurable gesture threshold (#27)

feat: AppShell view container with swipe-driven navigation (#27)

feat: background gradient transition system on swipe (#28)

feat: update plant.ts types to match OpenFarm API response (#29)

feat: useOpenFarmCrop hook with in-memory cache (#29)

feat: OpenFarm mock fixtures mirroring real API responses (#30)

feat: CompactPlantCard with expandable OpenFarm detail strip (#31)

feat: wire CompactPlantCard grid into outdoor-view (#31)